### PR TITLE
fix the error in the Procfile - it shouldn't dictate a port

### DIFF
--- a/Procfile
+++ b/Procfile
@@ -1,1 +1,1 @@
-web: gunicorn -b '127.0.0.1:8000' django_queue.wsgi
+web: gunicorn django_queue.wsgi


### PR DESCRIPTION
There's an error in the Procfile - as it is, it will never work on Heroku as it shouldn't specify a PORT number - Heroku supplies one.  This fixes it.
